### PR TITLE
feat: write and read response units gps coordinates to json file

### DIFF
--- a/src/controllers/reportController.js
+++ b/src/controllers/reportController.js
@@ -1,5 +1,7 @@
 const Report = require('../models/report');
-// const mapService = require('../services/map.service');
+const mapService = require('../services/map.service');
+
+const responeUnitsLocationFile = 'reponseUnitsCoordinates.json';
 
 exports.createReport = (req, res) => {
   const { reporter, location, imageUrl } = req.body;
@@ -95,6 +97,34 @@ exports.getReports = (req, res) => {
   })
     .catch((error) => {
       res.status(400).json({
+        error
+      });
+    });
+};
+
+exports.storeResponseUnitLocation = (req, res) => {
+  mapService.writeCoordinates(responeUnitsLocationFile, req.body)
+    .then(() => {
+      res.status(200).json({
+        message: 'Location stored successfully!'
+      });
+    })
+    .catch((error) => {
+      res.status(500).json({
+        error
+      });
+    });
+};
+
+exports.getResponseUnitsLocation = (req, res) => {
+  mapService.readCoordinates(responeUnitsLocationFile)
+    .then((locations) => {
+      res.status(200).json({
+        locations
+      });
+    })
+    .catch((error) => {
+      res.status(500).json({
         error
       });
     });

--- a/src/middleware/validationMiddleware.js
+++ b/src/middleware/validationMiddleware.js
@@ -6,8 +6,8 @@ const userSchema = joi.object({
   password: joi.string().min(6).max(15).required(),
   phoneNo: joi.string().pattern(/^([0-9])\d{10}$/).required(),
   emergencyContact: joi.object({
-    name: joi.string().pattern(/^[_A-z0-9]*((-|\s)*[_A-z0-9])*$/).required(),
-    phoneNo: joi.string().pattern(/^([0-9])\d{10}$/).disallow(joi.ref('/phoneNo')).required()
+    name: joi.string().pattern(/^[_A-z0-9]*((-|\s)*[_A-z0-9])*$/),
+    phoneNo: joi.string().pattern(/^([0-9])\d{10}$/).disallow(joi.ref('/phoneNo'))
   })
 }).options({ stripUnknown: true });
 
@@ -44,6 +44,14 @@ const responseUnitsSchema = joi.array().min(1).items(joi.object().keys({
   latitude: joi.number().required(),
   longitude: joi.number().required()
 })).required();
+
+const responseUnitLocationSchema = joi.object({
+  name: joi.string().required(),
+  location: {
+    latitude: joi.number().required(),
+    longitude: joi.number().required()
+  }
+}).options({ stripUnknown: true });
 
 const userValidation = (req, res, next) => {
   const { error } = userSchema.validate(req.body);
@@ -105,9 +113,23 @@ const coordinatesValidation = (victimCoord, responseUnitCoord, next) => {
   return next();
 };
 
+const responseUnitLocationValidation = (req, res, next) => {
+  const { error } = responseUnitLocationSchema.validate(req.body);
+
+  if (error) {
+    return res.status(422).json({
+      message: 'Invalid data schema',
+      error
+    });
+  }
+
+  return next();
+};
+
 module.exports = {
   userValidation,
   reportValidation,
   responseUnitValidation,
-  coordinatesValidation
+  coordinatesValidation,
+  responseUnitLocationValidation
 };

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -1,11 +1,13 @@
 const express = require('express');
-const { reportValidation } = require('../middleware/validationMiddleware');
+const { reportValidation, responseUnitLocationValidation } = require('../middleware/validationMiddleware');
 const auth = require('../middleware/authMiddleware');
 const reportCtrl = require('../controllers/reportController');
 
 const router = express.Router();
 
-router.post('/', auth, reportValidation, reportCtrl.createReport);
 router.get('/', auth, reportCtrl.getReports);
+router.post('/', auth, reportValidation, reportCtrl.createReport);
+router.post('/eru-location', responseUnitLocationValidation, reportCtrl.storeResponseUnitLocation);
+router.get('/eru-location', reportCtrl.getResponseUnitsLocation);
 
 module.exports = router;

--- a/src/services/map.service.js
+++ b/src/services/map.service.js
@@ -1,5 +1,7 @@
 const { Client, Status } = require('@googlemaps/google-maps-services-js');
 const geolib = require('geolib');
+const fs = require('fs');
+const lodash = require('lodash');
 
 // const destination = [
 //   { latitude: 6.246073, longitude: 5.636672 },
@@ -7,6 +9,8 @@ const geolib = require('geolib');
 //   { latitude: 6.034224, longitude: 5.673400 },
 //   { latitude: 6.190696, longitude: 5.656444 }
 // ];
+
+let destination = [];
 
 const getDistanceToNearestResponseUnit = (origin, destinations) => {
   const nearestResponseUnit = geolib.findNearest(origin, destinations);
@@ -31,6 +35,79 @@ const getDistanceToNearestResponseUnit = (origin, destinations) => {
   });
 };
 
+const readCoordinates = (filename) => new Promise(((resolve, reject) => {
+  fs.readFile(`./${filename}`, 'utf8', (err, data) => {
+    if (err) { // File doesn't exist
+      // const error = JSON.parse(JSON.stringify(err));
+      // error.message = err.stack.substring(err.stack.lastIndexOf(': ') + 1,
+      // err.stack.indexOf(','));
+
+      // Create the file
+      fs.writeFile(`./${filename}`, '[]', { flag: 'wx' }, (error) => {
+        if (error) {
+          reject(error);
+        }
+
+        resolve([]);
+      });
+    }
+
+    if (data) { // File exists
+      resolve(JSON.parse(data));
+    }
+  });
+}));
+
+const writeCoordinates = (filename, responseUnitObj) => new Promise((resolve, reject) => {
+  const { location: { latitude, longitude }, name } = responseUnitObj;
+  readCoordinates(filename)
+    .then((responseUnitCoordinates) => {
+      const locations = responseUnitCoordinates;
+
+      if (locations.length !== 0) {
+        destination = locations;
+      }
+
+      // Check if the responseUnit already logged a location
+      const responseUnit = lodash.find(destination, (data) => data.name === name);
+
+      if (!responseUnit) { // push new entry
+        destination.push({
+          name,
+          location: {
+            latitude,
+            longitude
+          }
+        });
+      } else { // update existing entry
+        lodash.map(destination, (data) => {
+          if (data.name === name) {
+            data.location = {
+              latitude,
+              longitude
+            };
+          }
+        });
+      }
+
+      // Convert to JSON and indent the array objects
+      const destinationJSON = JSON.stringify(destination, null, 2);
+
+      fs.writeFile(filename, destinationJSON, 'utf-8', (err) => {
+        if (err) {
+          reject(err);
+        }
+
+        resolve(true);
+      });
+    })
+    .catch((error) => {
+      reject(error);
+    });
+});
+
 module.exports = {
-  getDistanceToNearestResponseUnit
+  getDistanceToNearestResponseUnit,
+  readCoordinates,
+  writeCoordinates
 };


### PR DESCRIPTION
## Description
This allows the gps locations of responseUnits to be read quickly for geolocation services

Minor changes to the UserSchema for signup - emergencyContact no longer a required field

Fixes #21

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
